### PR TITLE
Fixed a case when poco class with attribute table with a multiword schema.

### DIFF
--- a/Dapper.SimpleCRUD/SimpleCRUD.cs
+++ b/Dapper.SimpleCRUD/SimpleCRUD.cs
@@ -856,6 +856,8 @@ namespace Dapper
 
         private static string Encapsulate(string databaseword)
         {
+            if (databaseword != null && databaseword.Length > 1 && databaseword[0] == '[') //has been already provided capsulated.
+                return databaseword;
             return string.Format(_encapsulation, databaseword);
         }
         /// <summary>


### PR DESCRIPTION
Fixed a case when poco class with attribute table with a multiword specified schema

is given multiword which each needs to be encapsulated, for example:
[Table("tablename", Schema="website.dbo")]
Tablename results in [website.dbo].[tablename] and the sql valid is [website].[dbo].[tablename].

A hotfix is to specify brackets in the schema name.
[Table("tablename", Schema="[website].[dbo]")]

Signed-off-by: Eli Belash elibelash@gmail.com
